### PR TITLE
EA-10: Allow device alias symlinks

### DIFF
--- a/init/devices.cpp
+++ b/init/devices.cpp
@@ -523,7 +523,6 @@ bool DeviceHandler::GetDeviceAlias(const std::string &upath, int major, int mino
         match_minor = (alias.Minor() == minor);
 
         if (match_productId && match_vendorId && match_major && match_minor) {
-            LOG(INFO) << "Will create link: " << alias.AliasTo();
             alias_link = alias.AliasTo();
             return true;
         }

--- a/init/devices.cpp
+++ b/init/devices.cpp
@@ -537,7 +537,7 @@ bool DeviceHandler::GetDeviceAlias(const std::string &upath, int major, int mino
     // If we can't associate an idVendor for the device, then we
     // silently quit this as we won't ever by able to create an
     // alias..
-    while ((parent_dir != "/" && parent_dir != ".")) {
+    while ((parent_dir != "/sys" && parent_dir != ".")) {
         std::string vendorId_path = parent_dir + "/idVendor";
 
         // Get the vendor ID

--- a/init/devices.h
+++ b/init/devices.h
@@ -34,6 +34,26 @@
 namespace android {
 namespace init {
 
+class Aliases {
+    private:
+    int minor_;
+    int major_;
+    int productId_;
+    int vendorId_;
+    std::string alias_to_;
+
+    public:
+    Aliases(const std::string& to, int productId, int vendorId, int major, int minor);
+
+    friend void TestAliases(const Aliases& expected, const Aliases& test);
+
+    int Minor() const { return minor_; };
+    int Major() const { return major_; };
+    int ProductId() const { return productId_; };
+    int VendorId() const { return vendorId_; };
+    std::string AliasTo() const { return alias_to_; };
+};
+
 class Permissions {
   public:
     friend void TestPermissions(const Permissions& expected, const Permissions& test);
@@ -112,7 +132,9 @@ class DeviceHandler : public UeventHandler {
 
     DeviceHandler();
     DeviceHandler(std::vector<Permissions> dev_permissions,
-                  std::vector<SysfsPermissions> sysfs_permissions, std::vector<Subsystem> subsystems,
+                  std::vector<SysfsPermissions> sysfs_permissions,
+                  std::vector<Subsystem> subsystems,
+                  std::vector<Aliases> aliases,
                   std::set<std::string> boot_devices, bool skip_restorecon);
     virtual ~DeviceHandler() = default;
 
@@ -127,13 +149,16 @@ class DeviceHandler : public UeventHandler {
         const std::string& path, const std::vector<std::string>& links) const;
     void MakeDevice(const std::string& path, bool block, int major, int minor,
                     const std::vector<std::string>& links) const;
-    void HandleDevice(const std::string& action, const std::string& devpath, bool block, int major,
+    void HandleDevice(const std::string& action, const std::string& devpath,
+                      const std::string& upath, bool block, int major,
                       int minor, const std::vector<std::string>& links) const;
     void FixupSysPermissions(const std::string& upath, const std::string& subsystem) const;
+    bool GetDeviceAlias(const std::string &upath, int major, int minor, std::string& alias_link) const;
 
     std::vector<Permissions> dev_permissions_;
     std::vector<SysfsPermissions> sysfs_permissions_;
     std::vector<Subsystem> subsystems_;
+    std::vector<Aliases> aliases_;
     std::set<std::string> boot_devices_;
     bool skip_restorecon_;
     std::string sysfs_mount_point_;

--- a/init/devices.h
+++ b/init/devices.h
@@ -43,15 +43,15 @@ class Aliases {
     std::string alias_to_;
 
     public:
+    static const int ANY;
+
     Aliases(const std::string& to, int productId, int vendorId, int major, int minor);
 
-    friend void TestAliases(const Aliases& expected, const Aliases& test);
-
-    int Minor() const { return minor_; };
-    int Major() const { return major_; };
-    int ProductId() const { return productId_; };
-    int VendorId() const { return vendorId_; };
     std::string AliasTo() const { return alias_to_; };
+
+    bool Matches(int productId, int vendorId, int major, int minor) const;
+
+    friend void TestAliases(const Aliases& expected, const Aliases& test);
 };
 
 class Permissions {

--- a/init/first_stage_mount.cpp
+++ b/init/first_stage_mount.cpp
@@ -221,6 +221,7 @@ FirstStageMount::FirstStageMount(Fstab fstab)
     auto boot_devices = android::fs_mgr::GetBootDevices();
     device_handler_ = std::make_unique<DeviceHandler>(
             std::vector<Permissions>{}, std::vector<SysfsPermissions>{}, std::vector<Subsystem>{},
+            std::vector<Aliases>(),
             std::move(boot_devices), false);
 
     super_partition_name_ = fs_mgr_get_super_partition_name();

--- a/init/ueventd.cpp
+++ b/init/ueventd.cpp
@@ -245,7 +245,9 @@ int ueventd_main(int argc, char** argv) {
     uevent_handlers.emplace_back(std::make_unique<DeviceHandler>(
             std::move(ueventd_configuration.dev_permissions),
             std::move(ueventd_configuration.sysfs_permissions),
-            std::move(ueventd_configuration.subsystems), android::fs_mgr::GetBootDevices(), true));
+            std::move(ueventd_configuration.subsystems),
+            std::move(ueventd_configuration.aliases),
+            android::fs_mgr::GetBootDevices(), true));
     uevent_handlers.emplace_back(std::make_unique<FirmwareHandler>(
             std::move(ueventd_configuration.firmware_directories)));
 

--- a/init/ueventd_parser.cpp
+++ b/init/ueventd_parser.cpp
@@ -116,7 +116,6 @@ Result<Success> ParseAliasLine(std::vector<std::string>&& args,
     *it++;
 
     // Format of alias lines: <to> <hex:productId> <hex:vendorId> <major> <minor>
-
     std::string& alias_to = *it++;
     std::string& productId_s = *it++;
     std::string& vendorId_s = *it++;
@@ -125,8 +124,17 @@ Result<Success> ParseAliasLine(std::vector<std::string>&& args,
 
     int productId = std::stoi(productId_s, 0, 16);
     int vendorId = std::stoi(vendorId_s, 0, 16);
-    int major = std::stoi(major_s);
-    int minor = std::stoi(minor_s);
+    int major, minor;
+
+    if (major_s == "*")
+        major = Aliases::ANY;
+    else
+        major = std::stoi(major_s);
+
+    if (minor_s == "*")
+        minor = Aliases::ANY;
+    else
+        minor = std::stoi(minor_s);
 
     aliases->emplace_back(alias_to, productId, vendorId, major, minor);
 

--- a/init/ueventd_parser.h
+++ b/init/ueventd_parser.h
@@ -30,6 +30,7 @@ struct UeventdConfiguration {
     std::vector<SysfsPermissions> sysfs_permissions;
     std::vector<Permissions> dev_permissions;
     std::vector<std::string> firmware_directories;
+    std::vector<Aliases> aliases;
     bool enable_modalias_handling = false;
     size_t uevent_socket_rcvbuf_size = 0;
 };

--- a/init/ueventd_parser_test.cpp
+++ b/init/ueventd_parser_test.cpp
@@ -201,7 +201,9 @@ firmware_directories /more
 
 uevent_socket_rcvbuf_size 6M
 
-alias /dev/test 1 2 3 4
+alias /dev/test1 1 2 3 4
+alias /dev/test2 1 2 * *
+alias /dev/test3 1 2 3 *
 
 #ending comment
 )";
@@ -232,7 +234,9 @@ alias /dev/test 1 2 3 4
     };
 
     auto aliases = std::vector<Aliases>{
-        {"/dev/test", 1, 2, 3, 4}
+        {"/dev/test1", 1, 2, 3, 4},
+        {"/dev/test2", 1, 2, -1, -1},
+        {"/dev/test3", 1, 2, 3, -1}
     };
 
     size_t uevent_socket_rcvbuf_size = 6 * 1024 * 1024;


### PR DESCRIPTION
Added a new configuration instruction in ueventd to make alias symlinks
to specific devices in /dev. The instruction uses the USB vendorId and
productId field as well as the major/minor of the device.

Change-Id: I0b670aeb4358b75ebc55c011589def9ab50e2f62