### PR TITLE
EA-336: Make modem logs persistent

### DIFF
--- a/logcat/logcatd.rc
+++ b/logcat/logcatd.rc
@@ -34,7 +34,8 @@ on load_persist_props_action
 on property:logd.logpersistd.enable=true && property:logd.logpersistd=logcatd
     # all exec/services are called with umask(077), so no gain beyond 0700
     mkdir /data/misc/logd 0700 logd log
-    start logcatd
+    start logcatd-radio
+    start logcatd-main
 
 # stop logcatd service and clear data
 on property:logd.logpersistd.enable=true && property:logd.logpersistd=clear
@@ -47,14 +48,24 @@ on property:logd.logpersistd.enable=true && property:logd.logpersistd=clear
 # stop logcatd service
 on property:logd.logpersistd=stop
     setprop persist.logd.logpersistd ""
-    stop logcatd
+    stop logcatd-radio
+    stop logcatd-main
     setprop logd.logpersistd ""
 
 on property:logd.logpersistd.enable=false
     stop logcatd
 
 # logcatd service
-service logcatd /system/bin/logcatd -L -b ${logd.logpersistd.buffer:-all} -v threadtime -v usec -v printable -D -f /data/misc/logd/logcat -r 1024 -n ${logd.logpersistd.size:-256} --id=${ro.build.id}
+service logcatd-radio /system/bin/logcatd -L -b radio -v threadtime -v usec -v printable -D -f /data/misc/logd/radio -r ${logd.logpersistd.rotate_size.radio:-1024} -n ${logd.logpersistd.size.radio:-256} --id=${ro.build.id}
+    class late_start
+    disabled
+    # logd for write to /data/misc/logd, log group for read from log daemon
+    user logd
+    group log
+    writepid /dev/cpuset/system-background/tasks
+    oom_score_adjust -600
+
+service logcatd-main /system/bin/logcatd -L -b main -v threadtime -v usec -v printable -D -f /data/misc/logd/logcat -r ${logd.logpersistd.rotate_size.main:-1024} -n ${logd.logpersistd.size.main:-256} --id=${ro.build.id}
     class late_start
     disabled
     # logd for write to /data/misc/logd, log group for read from log daemon


### PR DESCRIPTION
Expand the 'logcatd' service to split persistent logs between radio and standard
logs. Also makes it so that they can be configured invidually.