### PR TITLE
JC-526: Support LARA-R6 modem with USB device aliasing logic

### DIFF
--- a/init/first_stage_init.cpp
+++ b/init/first_stage_init.cpp
@@ -121,9 +121,11 @@ int FirstStageMain(int argc, char** argv) {
     CHECKCALL(mkdir("/dev/pts", 0755));
     CHECKCALL(mkdir("/dev/socket", 0755));
     // u-blox modifications
-    // Added for using u-blox MUX    
+    // Added for using u-blox MUX
     CHECKCALL(mount("devpts", "/dev/pts", "devpts", 0, "mode=0660"));
-    // u-blox modifications end    
+    //CHECKCALL(mount("devpts", "/dev/pts", "devpts", 0, NULL));
+    // u-blox modifications end
+
 #define MAKE_STR(x) __STRING(x)
     CHECKCALL(mount("proc", "/proc", "proc", 0, "hidepid=2,gid=" MAKE_STR(AID_READPROC)));
 #undef MAKE_STR

--- a/libcutils/properties.cpp
+++ b/libcutils/properties.cpp
@@ -108,10 +108,16 @@ int32_t property_get_int32(const char *key, int32_t default_value) {
 #include <sys/_system_properties.h>
 
 int property_set(const char *key, const char *value) {
+    // u-blox modifications
+    ALOGE("property_set() - Key=[%s],Value=[%s]", key, value);
+    // u-blox modifications end
     return __system_property_set(key, value);
 }
 
 int property_get(const char *key, char *value, const char *default_value) {
+    // u-blox modifications
+    ALOGE("property_get() - Key=[%s],Value=[%s]", key, value);
+    // u-blox modifications end
     int len = __system_property_get(key, value);
     if (len > 0) {
         return len;

--- a/liblog/logger_write.cpp
+++ b/liblog/logger_write.cpp
@@ -444,6 +444,7 @@ int __android_log_buf_write(int bufID, int prio, const char* tag, const char* ms
       case 'C':
         if (strcmp(tag + 1, "CDMA" + 1)) break;
         goto inform;
+      // u-blox modifications
       case 'M':
         if (strcmp(tag + 1, "MUXD" + 1)) break;
         goto inform;
@@ -453,13 +454,16 @@ int __android_log_buf_write(int bufID, int prio, const char* tag, const char* ms
       case 'i':
         if (strncmp(tag + 1, "init.gprs" + 1, strlen("init.gprs") - 1)) break;
         goto inform;
+      // u-blox modifications end
       case 'P':
         if (strcmp(tag + 1, "PHONE" + 1)) break;
       /* FALLTHRU */
       inform:
         bufID = LOG_ID_RADIO;
+        // u-blox modifications
         snprintf(tmp_tag, sizeof(tmp_tag), "use-Rlog/RLOG-%s", tag);
         tag = tmp_tag;
+        // u-blox modifications end
         [[fallthrough]];
       default:
         break;

--- a/rootdir/init.ublox.rc
+++ b/rootdir/init.ublox.rc
@@ -1,55 +1,68 @@
-# Copyright 2017 ublox Lahore Ltd.  All rights reserved.
-#
-############################################ READ ME ###############################################
-################################ TO ADD CUSTOMIZE FILE IN init.rc ##################################
-# Usage:                                                                                           #
-#   To use this file in android AOSP.                                                              #
-#       1. Copy "init.ublox.rc" to system/core/rootdir                                             #   
-#       2. Add "import /init.ublox.rc" in init.rc file at path system/core/rootdir/init.rc         #
-#       3. Refer "Section-B" of RIL App Note for other OS related changes.                         #
-#       4. Recompile android to make changes effective.                                            #
-#                                                                                                  #
-#   This file is distributed in following sections:                                                #
-#       >> Section-1 is related to actions on trigger post-fs-data                                 #
-#       >> Section-2 is related to actions on trigger boot                                         #
-#       >> Section-3 is related to Data Call servcices                                             #
-#       >> Section-4 is related to GSM MUX service                                                 #
-#       >> Section-5 is related to Old RIL releases (deprecated)                                   #
-#       >> Section-6 is related to Remote testing (u-blox internal)                                #
-#                                                                                                  #
-#                                                                                                  #
-# NOTE: For GSMMUX Service configuration [Section-4], carefully read notes inside the section.     #
-#                                                                                                  #
-# NOTE: For Android 8.1, Android 9.X, Android 10.X and above, see below instructions:              #
-#       1. Section-1 "on post-fs-data" required changes:                                           #
-#          >> Comment "mkdir /data/vendor 0770 root radio"                                         #
-#                                                                                                  #
-#       2. Section-3 "Data Call Services" required changes:                                        #
-#          >> Comment "service pppd_data0 /system/bin/init.gprs-pppd"                              #
-#          >> Add     "service pppd_data0 /vendor/bin/init.gprs-pppd"                              #
-#          >> Comment "service pppd_data1 /system/bin/init.gprs-pppd"                              #
-#          >> Add     "service pppd_data1 /vendor/bin/init.gprs-pppd"                              #
-#          >> Comment "service pppd_data2 /system/bin/init.gprs-pppd"                              #
-#          >> Add     "service pppd_data2 /vendor/bin/init.gprs-pppd"                              #
-#          >> Comment "service pppd_data3 /system/bin/init.gprs-pppd"                              #
-#          >> Add     "service pppd_data3 /vendor/bin/init.gprs-pppd"                              #
-#          >> Comment "service pppd_term /system/bin/stop_pppd 15"                                 #
-#          >> Add     "service pppd_term /vendor/bin/stop_pppd 15"                                 #
-#          >> Comment "service pppd_kill /system/bin/stop_pppd 9"                                  #
-#          >> Add     "service pppd_kill /vendor/bin/stop_pppd 9"                                  #
-#          >> Comment "service netd_ena /system/bin/init_data"                                     #
-#          >> Add     "service netd_ena /vendor/bin/init_data"                                     #
-#          >> Comment "service netd_dis /system/bin/stop_data"                                     #
-#          >> Add     "service netd_dis /vendor/bin/stop_data"                                     #
-#                                                                                                  #
-#                                                                                                  #
-####################################################################################################
+############################################# READ ME ###############################################
+# Copyright 2020 u-blox AG, Thalwil, Switzerland												    #
+#                                                                                                   #
+# Licensed under the Apache License, Version 2.0 (the "License");                                   #
+# you may not use this file except in compliance with the License.                                  #
+# You may obtain a copy of the License at                                                           #
+#                                                                                                   #
+# http://www.apache.org/licenses/LICENSE-2.0                                                        #
+# #                                                                                                 #
+# Unless required by applicable law or agreed to in writing, software                               #
+# distributed under the License is distributed on an "AS IS" BASIS,                                 #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                          #
+# See the License for the specific language governing permissions and                               #
+# limitations under the License.                                                                    #
+############################################ READ ME ################################################
+################################ TO ADD CUSTOMIZE FILE IN init.rc ###################################
+# Usage:                                                                                            #
+#   To use this file in android AOSP.                                                               #
+#       1. Copy "init.ublox.rc" to system/core/rootdir                                              #
+#       2. Add "import /init.ublox.rc" in init.rc file at path system/core/rootdir/init.rc          #
+#       3. Refer "Section-B" of RIL App Note for other OS related changes.                          #
+#       4. Recompile android to make changes effective.                                             #
+#                                                                                                   #
+#   This file is distributed in following sections:                                                 #
+#       >> Section-1 is related to actions on trigger post-fs-data                                  #
+#       >> Section-2 is related to actions on trigger boot                                          #
+#       >> Section-3 is related to Data Call servcices                                              #
+#       >> Section-4 is related to GSM MUX service                                                  #
+#       >> Section-5 is related to Old RIL releases (deprecated)                                    #
+#       >> Section-6 is related to Remote testing (u-blox internal)                                 #
+#                                                                                                   #
+#                                                                                                   #
+# NOTE: For GSMMUX Service configuration [Section-4], carefully read notes inside the section.      #
+#                                                                                                   #
+# NOTE: For Android 8 and below, see below instructions:                                            #
+#       1. Section-1 "on post-fs-data" required changes:                                            #
+#          >> Uncomment "mkdir /data/vendor 0770 root radio"                                        #
+#                                                                                                   #
+#       2. Section-3 "Data Call Services" required changes:                                         #
+#          >> Comment "service pppd_data0 /vendor/bin/init.gprs-pppd"                               #
+#          >> Add     "service pppd_data0 /system/bin/init.gprs-pppd"                               #
+#          >> Comment "service pppd_data1 /vendor/bin/init.gprs-pppd"                               #
+#          >> Add     "service pppd_data1 /system/bin/init.gprs-pppd"                               #
+#          >> Comment "service pppd_data2 /vendor/bin/init.gprs-pppd"                               #
+#          >> Add     "service pppd_data2 /system/bin/init.gprs-pppd"                               #
+#          >> Comment "service pppd_data3 /vendor/bin/init.gprs-pppd"                               #
+#          >> Add     "service pppd_data3 /system/bin/init.gprs-pppd"                               #
+#          >> Comment "service pppd_term /vendor/bin/stop_pppd 15"                                  #
+#          >> Add     "service pppd_term /system/bin/stop_pppd 15"                                  #
+#          >> Comment "service pppd_kill /vendor/bin/stop_pppd 9"                                   #
+#          >> Add     "service pppd_kill /system/bin/stop_pppd 9"                                   #
+#          >> Comment "service rawip_ena /vendor/bin/init_rmnet"                                    #
+#          >> Add     "service rawip_ena /system/bin/init_rmnet"                                    #
+#          >> Comment "service netd_ena /vendor/bin/init_data"                                      #
+#          >> Add     "service netd_ena /system/bin/init_data"                                      #
+#          >> Comment "service netd_dis /vendor/bin/stop_data"                                      #
+#          >> Add     "service netd_dis /system/bin/stop_data"                                      #
+#                                                                                                   #
+#####################################################################################################
 
 
-################################# [Section-1] on post-fs-data ######################################
+################################# [Section-1] on post-fs-data #######################################
 on post-fs-data
     # Create Directory for data/vendor/uril
-	# Comment for android 9.x and above
+    # Uncomment for android 8.x and below
     mkdir /data/vendor 0770 root radio
 
     mkdir /data/vendor/uril 0770 root radio
@@ -58,102 +71,104 @@ on post-fs-data
     chmod 660 /data/vendor/uril/repository.txt
     chown root radio /data/vendor/uril/repository.txt
 
-################################# [Section-2] on boot ##############################################
-on boot   
-    setprop "net.uril.repository" "ready"
+################################# [Section-2] on boot ###############################################
+on boot
+    setprop "vendor.ubx.uril.repository" "ready"
 
-    # Customization for logging (Can be commented if not required)    
+    # Customization for logging (Can be commented if not required)
     # Increase default log buffer size
     setprop persist.logd.size 16777216
     setprop service.adb.tcp.port 5555
 
 
-############################################ SERVICES ##############################################
+############################################ SERVICES ###############################################
 
-################################# [Section-3] Data Call Services ###################################
-service pppd_data0 /system/bin/init.gprs-pppd
-    user root
-    group radio cache inet misc
-    disabled
-    oneshot    
-
-service pppd_data1 /system/bin/init.gprs-pppd
-    user root
-    group radio cache inet misc
-    disabled
-    oneshot    
-
-service pppd_data2 /system/bin/init.gprs-pppd
-    user root
-    group radio cache inet misc
-    disabled
-    oneshot    
-
-service pppd_data3 /system/bin/init.gprs-pppd
-    user root
-    group radio cache inet misc
-    disabled
-    oneshot    
-
-service pppd_term /system/bin/stop_pppd 15
+################################# [Section-3] Data Call Services ####################################
+service pppd_data0 /vendor/bin/init.gprs-pppd
     user root
     group radio cache inet misc
     disabled
     oneshot
 
-service pppd_kill /system/bin/stop_pppd 9
+service pppd_data1 /vendor/bin/init.gprs-pppd
     user root
     group radio cache inet misc
     disabled
     oneshot
 
-service netd_ena /system/bin/init_data
+service pppd_data2 /vendor/bin/init.gprs-pppd
     user root
     group radio cache inet misc
     disabled
     oneshot
 
-service netd_dis /system/bin/stop_data
+service pppd_data3 /vendor/bin/init.gprs-pppd
+    user root
+    group radio cache inet misc
+    disabled
+    oneshot
+
+service pppd_term /vendor/bin/stop_pppd 15
+    user root
+    group radio cache inet misc
+    disabled
+    oneshot
+
+service pppd_kill /vendor/bin/stop_pppd 9
+    user root
+    group radio cache inet misc
+    disabled
+    oneshot
+
+service rawip_ena /vendor/bin/init_rmnet
+    user root
+    group radio cache inet misc
+    disabled
+    oneshot
+
+service netd_ena /vendor/bin/init_data
+    user root
+    group radio cache inet misc
+    disabled
+    oneshot
+
+service netd_dis /vendor/bin/stop_data
     user root
     group radio cache inet misc
     disabled
     oneshot
 
 
-################################# [Section-4] GSMMUX Service  ######################################
+################################# [Section-4] GSMMUX Service  #######################################
 # UnComment this section if GSMMUX package needs to be used.
 #
-# NOTE: For Android 6.X and previous versions, uncomment below line: 	
-#service gsmmuxd /system/bin/logwrapper /system/bin/gsm0710muxd
 #
-# NOTE: For Android 7.X uncomment below line:
+# NOTE: For Android 8.X uncomment below line:
 #service gsmmuxd /system/bin/gsm0710muxd
 #
-# NOTE: For Android 8.0 uncomment below line:
-#service vendor.gsmmuxd /system/bin/gsm0710muxd
-#
-# NOTE: For Android 8.1 AND Android 9.X, uncomment below line:			  				
+# NOTE: For Android 9.X, Android 10.X, Android 11.X, Android 12.X and Android 13.X, uncomment below line:
 #service vendor.gsmmuxd /vendor/bin/gsm0710muxd
+#
 #    class main
 #    user radio
 #    group radio cache inet misc
 #    disabled
 #    oneshot
 #
-# NOTE: For Android 8.X and older versions, uncomment below line:
+# NOTE: For Android 8.X uncomment below line:
 #service mux_stop /system/bin/stop_muxd 15
 #
-# NOTE: For Android 8.1 AND Android 9.X and later, uncomment below line:			  				
+# NOTE: For Android 9.X, Android 10.X, Android 11.X, Android 12.X and Android 13.X, uncomment below line:
 #service mux_stop /vendor/bin/stop_muxd 15
+#
 #    class main
-#    user radio      
+#    user radio
 #    group radio cache inet misc
 #    disabled
 #    oneshot
 #
 
-
-################################# [Section-5] (deprecated) #########################################
+################################# [Section-5] (deprecated) ##########################################
 # Prepare u-blox RIL repository
 # UnComment "uril-repo" service only for RIL Release RIL_SW_08.XX and below [Old Releases]
 #service uril-repo /system/bin/uril-repo.sh
@@ -164,7 +179,7 @@ service netd_dis /system/bin/stop_data
 #    oneshot
 
 
-################################# [Section-6] [u-blox internal only] ###############################
+################################# [Section-6] [u-blox internal only] ################################
 #service gsmmuxd /system/bin/logwrapper /system/bin/gsm0710muxd
 #    class main
 #    user radio
@@ -178,24 +193,24 @@ service netd_dis /system/bin/stop_data
 #    socket rild-debug stream 660 radio system
 #    user radio
 #    group radio cache inet misc audio sdcard_r sdcard_rw log
-#   
+#
 # To use below usb vertualization tool, below changes should be made:
 #       1. Set Mode option in TTY Group to "remote" present in the repository.txt file.
 #       2. Set CommandPort option in TTY Group to /data/vendor/uril/ttyUBX0 in the repository.txt file.
 #       3. Add line "BOARD_KERNEL_CMDLINE += androidboot.selinux=permissive" in BoardConfig.mk file.
 #       4. Uncomment PRODUCT_PACKAGES line inside core_ublox.mk file to build ubxvclient and ubxvclient_data services.
 #       5. Uncomment below ubxvclient and ubxvclient_data services.
-# NOTE: For Android 7.X and above, remove "/system/bin/logwrapper" from below ubxvclient service
+# NOTE: For Android 8.X and above, remove "/system/bin/logwrapper" from below ubxvclient service
 #service ubxvclient /system/bin/logwrapper /system/bin/ubxvclient -p 9000 -i 10.11.1.108 -d /data/vendor/uril/ttyUBX0
 #    class main
 #    user radio
 #    group radio cache inet misc
-#    
-# NOTE: For Android 7.X and above, remove "/system/bin/logwrapper" from below ubxvclient_data service  
+#
+# NOTE: For Android 8.X and above, remove "/system/bin/logwrapper" from below ubxvclient_data service
 #service ubxvclient_data /system/bin/logwrapper /system/bin/ubxvclient_data -p 9001 -i 10.11.1.108 -d /data/vendor/uril/ttyUBX1
 #    class main
 #    user radio
 #    group radio cache inet misc
 #    disabled
-
-############################################ SERVICES ##############################################
+#
+############################################ SERVICES ###############################################


### PR DESCRIPTION
The LARA-R6 modem uses ttyUSB connections instead of ttyACM connections like the TOBY-R2. This change necessitates a unique aliasing logic for LARA-R6. This pull request introduces a logic specifically designed for USB device aliasing for the LARA-R6 modem.

Changes Made:
- Added a new logic block to handle USB device aliasing for the LARA-R6 modem.
- Modified the existing logic to find the interface number in a parent directory for the USB device.
- Implemented a mechanism to read the bInterfaceNumber from the sysfs path and convert it to the corresponding ACM interface number.
- Some files changes for the upgrade to RIL v16.01


Additional Notes:
- This change is specific to the LARA-R6 modem and should not affect the TOBY-R2 modem.
-  The existing logic for ttyACM devices is left unchanged.
